### PR TITLE
chore: change name of the email sender

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -19,6 +19,7 @@ end
 config :omsmailer,
   ecto_repos: [Omsmailer.Repo],
   from_address: System.get_env("SMTP_USER")
+  from_name: System.get_env("SMTP_NAME")
 
 # Configures the endpoint
 config :omsmailer, OmsmailerWeb.Endpoint,

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,8 +18,7 @@ end
 # General application configuration
 config :omsmailer,
   ecto_repos: [Omsmailer.Repo],
-  from_address: System.get_env("SMTP_USER")
-  from_name: System.get_env("SMTP_NAME")
+  from_address: System.get_env("SMTP_NAME")
 
 # Configures the endpoint
 config :omsmailer, OmsmailerWeb.Endpoint,


### PR DESCRIPTION
When mailer send an email as mailer@aegee.eu it used to appear as "mailer". With this line, we are able to modify that name. At the time of the commit, the variable contains "AEGEE"