### PR TITLE
chore(ci): update CircleCI orbs and images to latest versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 orbs:
-  node: circleci/node@6.1.0
-  slack: circleci/slack@4.13.3
+  node: circleci/node@7.2.1
+  slack: circleci/slack@6.1.2
 version: 2.1
 jobs:
   test:
     machine:
-      image: ubuntu-2204:2024.11.1
+      image: ubuntu-2204:2025.09.1
     environment:
       MIX_ENV: test
       SMTP_USER: mailer@aegee.eu
@@ -23,7 +23,7 @@ jobs:
       - run: SMTP_USER=mailer@aegee.eu mix coveralls
   build:
     docker:
-      - image: cimg/base:2024.09
+      - image: cimg/base:2025.12
         environment:
           MIX_ENV: test
           SMTP_USER: mailer@aegee.eu
@@ -38,7 +38,7 @@ jobs:
       - run: docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build --no-cache mailer
   docker-build-and-push:
     docker:
-      - image: cimg/node:20.17.0
+      - image: cimg/node:20.19.6
         environment:
           MIX_ENV: test
           SMTP_USER: mailer@aegee.eu


### PR DESCRIPTION
## Summary
- Update node orb: 6.1.0 → 7.2.1
- Update slack orb: 4.13.3 → 6.1.2
- Update ubuntu machine: 2024.11.1 → 2025.09.1
- Update cimg/node: 20.17.0 → 20.19.6
- Update cimg/base: 2024.09 → 2025.12

## Test plan
- [ ] Verify CircleCI builds pass with new versions

🤖 Generated with [Claude Code](https://claude.ai/code)